### PR TITLE
fix: build-and-test (galactic). 

### DIFF
--- a/src/tilde/test/test_tilde_node.cpp
+++ b/src/tilde/test/test_tilde_node.cpp
@@ -81,6 +81,7 @@ TEST_F(TestTildeNode, simple_case) {
 
   clock_pub->publish(clock_msg);
   rclcpp::spin_some(sensor_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(main_node);
 
   // prepare pub/sub
@@ -121,7 +122,9 @@ TEST_F(TestTildeNode, simple_case) {
   sensor_pub->publish(std::move(sensor_msg));
 
   rclcpp::spin_some(sensor_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(main_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(checker_node);
   EXPECT_TRUE(checker_sub_called);
 }
@@ -152,6 +155,7 @@ TEST_F(TestTildeNode, no_header_case) {
 
   clock_pub->publish(clock_msg);
   rclcpp::spin_some(sensor_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(main_node);
 
   // prepare pub/sub
@@ -191,7 +195,9 @@ TEST_F(TestTildeNode, no_header_case) {
   sensor_pub->publish(std::move(msg));
 
   rclcpp::spin_some(sensor_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(main_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(checker_node);
   EXPECT_TRUE(checker_sub_called);
 }
@@ -221,6 +227,7 @@ TEST_F(TestTildeNode, enable_tilde) {
 
   clock_pub->publish(clock_msg);
   rclcpp::spin_some(sensor_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(main_node);
 
   // prepare pub/sub
@@ -252,7 +259,9 @@ TEST_F(TestTildeNode, enable_tilde) {
   sensor_pub->publish(std::move(sensor_msg));
 
   rclcpp::spin_some(sensor_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(main_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(checker_node);
   EXPECT_EQ(checker_sub_called, false);
 }
@@ -307,6 +316,7 @@ TEST_F(TestTildeNode, register_message_as_input_find_subscription_time) {
   sensor_msg1.header.stamp = sensor_node->now();
   sensor_pub->publish(sensor_msg1);
   rclcpp::spin_some(sensor_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(main_node);
 
   // publish @124.321
@@ -331,6 +341,7 @@ TEST_F(TestTildeNode, register_message_as_input_find_subscription_time) {
   sensor_msg2.header.stamp = sensor_node->now();
   sensor_pub->publish(sensor_msg2);
   rclcpp::spin_some(sensor_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(main_node);
 
   // check
@@ -364,6 +375,7 @@ TEST_F(TestTildeNode, publish_top_level_stamp) {
 
   clock_pub->publish(clock_msg);
   rclcpp::spin_some(main_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(checker_node);
 
   // prepare checker subscription
@@ -386,6 +398,7 @@ TEST_F(TestTildeNode, publish_top_level_stamp) {
   main_pub->publish(msg);
 
   rclcpp::spin_some(main_node);
+  rclcpp::Rate(50).sleep();
   rclcpp::spin_some(checker_node);
 
   EXPECT_TRUE(checker_sub_called);


### PR DESCRIPTION
In a nutshel, we may care timing and retry when using `publish()` and `spin()` in unit test.

We had build-and-test (galactic) errors. For example,

- https://github.com/tier4/TILDE/runs/6975917894?check_suite_focus=true
- https://github.com/tier4/TILDE/runs/6995366430?check_suite_focus=true

The typical error message is the following.

```
2: /__w/TILDE/TILDE/src/tilde/test/test_tilde_node.cpp:321: Failure
2: Expected equality of these values:
2:   subscription_time_msg.sec
2:     Which is: 0
2:   clock_msg1.clock.sec
2:     Which is: 123
2: /__w/TILDE/TILDE/src/tilde/test/test_tilde_node.cpp:322: Failure
2: Expected equality of these values:
2:   subscription_time_msg.nanosec
2:     Which is: 0
2:   clock_msg1.clock.nanosec
2:     Which is: 456
```

This test checks when TildeNode received the input message. Thus it depends on the TildeNode internal clock.

By error message, it looks that 
(1) TildeNode received input message because checking "is the received message `found`?" is passed.
(2) but TildeNode received the input message at t = 0.0 as `subscription_time_msg.sec` is 0
(3) so, it looks TildeNode might not receive `/clock` topic.

We added sleep logic before spin, retry logic to receive `/clock` and check logic for clock.

By this PR, build-and-test (galactic) is passed.
Be aware that build-and-test (humble) has another error.