### PR TITLE
fix: support both galactic and humble

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,3 +1,3 @@
 {
-  "words": ["LTTNGUST", "Republisher", "Stee", "ipython", "republisher", "stee"]
+  "words": ["LTTNGUST", "Republisher", "Stee", "ipython", "republisher", "stee", "endmacro"]
 }

--- a/doc/README.md
+++ b/doc/README.md
@@ -93,6 +93,21 @@ rclcpp::Node の子クラスです。
 既存のアプリケーションに TILDE を組み込む際は以下の流れになります。
 ※ TODO: TILDE ライブラリ（\*.so）の取込み手順
 
+- packages.xml に以下を追加
+
+```xml
+<depend>tilde_cmake</depend>
+<depend>tilde</depend>
+```
+
+- CMakeLists.txt に以下を追加
+
+```cmake
+find_package(tilde_cmake REQUIRED)
+tilde_package()
+find_package(tilde REQUIRED)
+```
+
 - rclcpp::Node, rclcpp::Node::create_publisher, rclcpp::Node::create_subscription に代わり tilde の各 API の利用
   - rclcpp::Node とコンストラクタを tilde::TildeNode に置換
   - create_subscription() を create_tilde_subscription() に置換

--- a/src/tilde/CMakeLists.txt
+++ b/src/tilde/CMakeLists.txt
@@ -5,6 +5,12 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+if($ENV{ROS_DISTRO} STREQUAL "galactic")
+  add_compile_definitions("TILDE_ROS_VERSION=202103")
+else()
+  add_compile_definitions("TILDE_ROS_VERSION=202203")
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 # uncomment the following section in order to fill in

--- a/src/tilde/CMakeLists.txt
+++ b/src/tilde/CMakeLists.txt
@@ -5,21 +5,18 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-if($ENV{ROS_DISTRO} STREQUAL "galactic")
-  add_compile_definitions("TILDE_ROS_VERSION=202103")
-else()
-  add_compile_definitions("TILDE_ROS_VERSION=202203")
-endif()
-
 # find dependencies
 find_package(ament_cmake REQUIRED)
 # uncomment the following section in order to fill in
 # further dependencies manually.
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
+find_package(tilde_cmake REQUIRED)
 find_package(tilde_msg REQUIRED)
 find_package(rmw REQUIRED)
 find_package(LTTngUST REQUIRED)
+
+tilde_package()
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/src/tilde/include/tilde/stee_node.hpp
+++ b/src/tilde/include/tilde/stee_node.hpp
@@ -66,7 +66,7 @@ public:
       rclcpp::message_memory_strategy::MessageMemoryStrategy<CallbackMessageT, AllocatorT>,
     typename ConvertedMessageMemoryStrategyT =
       rclcpp::message_memory_strategy::MessageMemoryStrategy<ConvertedMessageT, AllocatorT>,
-#if TILDE_ROS_VERSION <= 202103
+#if ROS_DISTRO_GALACTIC
     typename SteeSubscriptionT = SteeSubscription<
       MessageT, ConvertedMessageT, AllocatorT, MessageMemoryStrategyT,
       ConvertedMessageMemoryStrategyT>

--- a/src/tilde/include/tilde/stee_node.hpp
+++ b/src/tilde/include/tilde/stee_node.hpp
@@ -64,12 +64,25 @@ public:
     typename MessageMemoryStrategyT =
       rclcpp::message_memory_strategy::MessageMemoryStrategy<CallbackMessageT, AllocatorT>,
     typename ConvertedMessageMemoryStrategyT =
-      rclcpp::message_memory_strategy::MessageMemoryStrategy<ConvertedMessageT, AllocatorT>,
+    rclcpp::message_memory_strategy::MessageMemoryStrategy<
+      ConvertedMessageT,
+      AllocatorT>,
+#if TILDE_ROS_VERSION <= 202103
+    typename SteeSubscriptionT = SteeSubscription<MessageT, ConvertedMessageT, AllocatorT,
+      MessageMemoryStrategyT, ConvertedMessageMemoryStrategyT>
+#else
     typename SteeSubscriptionT = SteeSubscription<
-      MessageT, ConvertedMessageT, AllocatorT, MessageMemoryStrategyT,
-      ConvertedMessageMemoryStrategyT>>
-  std::shared_ptr<SteeSubscriptionT> create_stee_subscription(
-    const std::string & topic_name, const rclcpp::QoS & qos, CallbackT && callback,
+      MessageT, ConvertedMessageT, AllocatorT,
+      typename rclcpp::TypeAdapter<MessageT>::custom_type,
+      typename rclcpp::TypeAdapter<MessageT>::ros_message_type,
+      MessageMemoryStrategyT, ConvertedMessageMemoryStrategyT>
+#endif
+  >
+  std::shared_ptr<SteeSubscriptionT>
+  create_stee_subscription(
+    const std::string & topic_name,
+    const rclcpp::QoS & qos,
+    CallbackT && callback,
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>(),
     typename MessageMemoryStrategyT::SharedPtr msg_mem_strategy =

--- a/src/tilde/include/tilde/stee_node.hpp
+++ b/src/tilde/include/tilde/stee_node.hpp
@@ -64,25 +64,20 @@ public:
     typename MessageMemoryStrategyT =
       rclcpp::message_memory_strategy::MessageMemoryStrategy<CallbackMessageT, AllocatorT>,
     typename ConvertedMessageMemoryStrategyT =
-    rclcpp::message_memory_strategy::MessageMemoryStrategy<
-      ConvertedMessageT,
-      AllocatorT>,
+      rclcpp::message_memory_strategy::MessageMemoryStrategy<ConvertedMessageT, AllocatorT>,
 #if TILDE_ROS_VERSION <= 202103
-    typename SteeSubscriptionT = SteeSubscription<MessageT, ConvertedMessageT, AllocatorT,
-      MessageMemoryStrategyT, ConvertedMessageMemoryStrategyT>
+    typename SteeSubscriptionT = SteeSubscription<
+      MessageT, ConvertedMessageT, AllocatorT, MessageMemoryStrategyT,
+      ConvertedMessageMemoryStrategyT>
 #else
     typename SteeSubscriptionT = SteeSubscription<
-      MessageT, ConvertedMessageT, AllocatorT,
-      typename rclcpp::TypeAdapter<MessageT>::custom_type,
-      typename rclcpp::TypeAdapter<MessageT>::ros_message_type,
-      MessageMemoryStrategyT, ConvertedMessageMemoryStrategyT>
+      MessageT, ConvertedMessageT, AllocatorT, typename rclcpp::TypeAdapter<MessageT>::custom_type,
+      typename rclcpp::TypeAdapter<MessageT>::ros_message_type, MessageMemoryStrategyT,
+      ConvertedMessageMemoryStrategyT>
 #endif
-  >
-  std::shared_ptr<SteeSubscriptionT>
-  create_stee_subscription(
-    const std::string & topic_name,
-    const rclcpp::QoS & qos,
-    CallbackT && callback,
+    >
+  std::shared_ptr<SteeSubscriptionT> create_stee_subscription(
+    const std::string & topic_name, const rclcpp::QoS & qos, CallbackT && callback,
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options =
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>(),
     typename MessageMemoryStrategyT::SharedPtr msg_mem_strategy =

--- a/src/tilde/include/tilde/stee_subscription.hpp
+++ b/src/tilde/include/tilde/stee_subscription.hpp
@@ -23,7 +23,7 @@
 namespace tilde
 {
 
-#if TILDE_ROS_VERSION <= 202103
+#if ROS_DISTRO_GALACTIC
 template <
   typename CallbackMessageT,
   typename ConvertedCallbackMessageT = ConvertedMessageType<CallbackMessageT>,
@@ -46,7 +46,7 @@ template <
 class SteeSubscription
 {
 private:
-#if TILDE_ROS_VERSION <= 202103
+#if ROS_DISTRO_GALACTIC
   using SubscriptionT = rclcpp::Subscription<CallbackMessageT, AllocatorT, MessageMemoryStrategyT>;
   using ConvertedSubscriptionT =
     rclcpp::Subscription<ConvertedCallbackMessageT, AllocatorT, ConvertedMessageMemoryStrategyT>;

--- a/src/tilde/include/tilde/stee_subscription.hpp
+++ b/src/tilde/include/tilde/stee_subscription.hpp
@@ -23,20 +23,57 @@
 namespace tilde
 {
 
-template <
+#if TILDE_ROS_VERSION <= 202103
+template<
   typename CallbackMessageT,
   typename ConvertedCallbackMessageT = ConvertedMessageType<CallbackMessageT>,
   typename AllocatorT = std::allocator<void>,
-  typename MessageMemoryStrategyT =
-    rclcpp::message_memory_strategy::MessageMemoryStrategy<CallbackMessageT, AllocatorT>,
-  typename ConvertedMessageMemoryStrategyT =
-    rclcpp::message_memory_strategy::MessageMemoryStrategy<ConvertedCallbackMessageT, AllocatorT> >
+  typename MessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<
+    CallbackMessageT,
+    AllocatorT>,
+  typename ConvertedMessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<
+    ConvertedCallbackMessageT,
+    AllocatorT>
+>
+#else
+template<
+  typename MessageT,
+  typename ConvertedMessageT = ConvertedMessageType<MessageT>,
+  typename AllocatorT = std::allocator<void>,
+  typename SubscribedT = typename rclcpp::TypeAdapter<MessageT>::custom_type,
+  typename ROSMessageT = typename rclcpp::TypeAdapter<MessageT>::ros_message_type,
+  typename MessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<
+    ROSMessageT,
+    AllocatorT>,
+  typename ConvertedMessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<
+    ConvertedMessageT,
+    AllocatorT>
+>
+#endif
 class SteeSubscription
 {
 private:
-  using SubscriptionT = rclcpp::Subscription<CallbackMessageT, AllocatorT, MessageMemoryStrategyT>;
+#if TILDE_ROS_VERSION <= 202103
+  using SubscriptionT = rclcpp::Subscription<CallbackMessageT,
+                                             AllocatorT,
+                                             MessageMemoryStrategyT>;
+  using ConvertedSubscriptionT = rclcpp::Subscription<ConvertedCallbackMessageT,
+                                                      AllocatorT,
+                                                      ConvertedMessageMemoryStrategyT>;
+#else
+  using SubscriptionT =
+      rclcpp::Subscription<MessageT,
+                           AllocatorT,
+                           SubscribedT,
+                           ROSMessageT,
+                           MessageMemoryStrategyT>;
   using ConvertedSubscriptionT =
-    rclcpp::Subscription<ConvertedCallbackMessageT, AllocatorT, ConvertedMessageMemoryStrategyT>;
+      rclcpp::Subscription<ConvertedMessageT,
+                           AllocatorT,
+                           typename rclcpp::TypeAdapter<ConvertedMessageT>::custom_type,
+                           typename rclcpp::TypeAdapter<ConvertedMessageT>::ros_message_type,
+                           ConvertedMessageMemoryStrategyT>;
+#endif
 
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(SteeSubscription)

--- a/src/tilde/include/tilde/stee_subscription.hpp
+++ b/src/tilde/include/tilde/stee_subscription.hpp
@@ -24,55 +24,39 @@ namespace tilde
 {
 
 #if TILDE_ROS_VERSION <= 202103
-template<
+template <
   typename CallbackMessageT,
   typename ConvertedCallbackMessageT = ConvertedMessageType<CallbackMessageT>,
   typename AllocatorT = std::allocator<void>,
-  typename MessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<
-    CallbackMessageT,
-    AllocatorT>,
-  typename ConvertedMessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<
-    ConvertedCallbackMessageT,
-    AllocatorT>
->
+  typename MessageMemoryStrategyT =
+    rclcpp::message_memory_strategy::MessageMemoryStrategy<CallbackMessageT, AllocatorT>,
+  typename ConvertedMessageMemoryStrategyT =
+    rclcpp::message_memory_strategy::MessageMemoryStrategy<ConvertedCallbackMessageT, AllocatorT> >
 #else
-template<
-  typename MessageT,
-  typename ConvertedMessageT = ConvertedMessageType<MessageT>,
+template <
+  typename MessageT, typename ConvertedMessageT = ConvertedMessageType<MessageT>,
   typename AllocatorT = std::allocator<void>,
   typename SubscribedT = typename rclcpp::TypeAdapter<MessageT>::custom_type,
   typename ROSMessageT = typename rclcpp::TypeAdapter<MessageT>::ros_message_type,
-  typename MessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<
-    ROSMessageT,
-    AllocatorT>,
-  typename ConvertedMessageMemoryStrategyT = rclcpp::message_memory_strategy::MessageMemoryStrategy<
-    ConvertedMessageT,
-    AllocatorT>
->
+  typename MessageMemoryStrategyT =
+    rclcpp::message_memory_strategy::MessageMemoryStrategy<ROSMessageT, AllocatorT>,
+  typename ConvertedMessageMemoryStrategyT =
+    rclcpp::message_memory_strategy::MessageMemoryStrategy<ConvertedMessageT, AllocatorT> >
 #endif
 class SteeSubscription
 {
 private:
 #if TILDE_ROS_VERSION <= 202103
-  using SubscriptionT = rclcpp::Subscription<CallbackMessageT,
-                                             AllocatorT,
-                                             MessageMemoryStrategyT>;
-  using ConvertedSubscriptionT = rclcpp::Subscription<ConvertedCallbackMessageT,
-                                                      AllocatorT,
-                                                      ConvertedMessageMemoryStrategyT>;
+  using SubscriptionT = rclcpp::Subscription<CallbackMessageT, AllocatorT, MessageMemoryStrategyT>;
+  using ConvertedSubscriptionT =
+    rclcpp::Subscription<ConvertedCallbackMessageT, AllocatorT, ConvertedMessageMemoryStrategyT>;
 #else
   using SubscriptionT =
-      rclcpp::Subscription<MessageT,
-                           AllocatorT,
-                           SubscribedT,
-                           ROSMessageT,
-                           MessageMemoryStrategyT>;
-  using ConvertedSubscriptionT =
-      rclcpp::Subscription<ConvertedMessageT,
-                           AllocatorT,
-                           typename rclcpp::TypeAdapter<ConvertedMessageT>::custom_type,
-                           typename rclcpp::TypeAdapter<ConvertedMessageT>::ros_message_type,
-                           ConvertedMessageMemoryStrategyT>;
+    rclcpp::Subscription<MessageT, AllocatorT, SubscribedT, ROSMessageT, MessageMemoryStrategyT>;
+  using ConvertedSubscriptionT = rclcpp::Subscription<
+    ConvertedMessageT, AllocatorT, typename rclcpp::TypeAdapter<ConvertedMessageT>::custom_type,
+    typename rclcpp::TypeAdapter<ConvertedMessageT>::ros_message_type,
+    ConvertedMessageMemoryStrategyT>;
 #endif
 
 public:

--- a/src/tilde/package.xml
+++ b/src/tilde/package.xml
@@ -13,6 +13,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rmw</depend>
+  <depend>tilde_cmake</depend>
   <depend>tilde_msg</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/src/tilde_cmake/CMakeLists.txt
+++ b/src/tilde_cmake/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.8)
+project(tilde_cmake)
+
+# find dependencies
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS
+  "tilde_cmake-extras.cmake"
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+    cmake
+)

--- a/src/tilde_cmake/README.md
+++ b/src/tilde_cmake/README.md
@@ -1,0 +1,18 @@
+# tilde_cmake
+
+This package provides CMake scripts for Tilde.
+
+## Usage
+
+### tilde_package.cmake
+
+Call `tilde_package()` before defining build targets, which will set common options for Tilde.
+
+```cmake
+cmake_minimum_required(VERSION 3.5)
+project(package_name)
+
+find_package(tilde_cmake REQUIRED)
+tilde_package()
+find_package(tilde)
+```

--- a/src/tilde_cmake/cmake/tilde_package.cmake
+++ b/src/tilde_cmake/cmake/tilde_package.cmake
@@ -1,0 +1,25 @@
+# Copyright 2022 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+macro(tilde_package)
+  # Set ROS_DISTRO macros
+  set(ROS_DISTRO $ENV{ROS_DISTRO})
+  if(${ROS_DISTRO} STREQUAL "rolling")
+    add_compile_definitions(ROS_DISTRO_ROLLING)
+  elseif(${ROS_DISTRO} STREQUAL "galactic")
+    add_compile_definitions(ROS_DISTRO_GALACTIC)
+  elseif(${ROS_DISTRO} STREQUAL "humble")
+    add_compile_definitions(ROS_DISTRO_HUMBLE)
+  endif()
+endmacro()

--- a/src/tilde_cmake/package.xml
+++ b/src/tilde_cmake/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>tilde_cmake</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="y-okumura@isp.co.jp">y-okumura</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>caret_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/tilde_cmake/tilde_cmake-extras.cmake
+++ b/src/tilde_cmake/tilde_cmake-extras.cmake
@@ -1,0 +1,15 @@
+# Copyright 2022 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include("${tilde_cmake_DIR}/tilde_package.cmake")

--- a/src/tilde_sample/CMakeLists.txt
+++ b/src/tilde_sample/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
+find_package(tilde_cmake REQUIRED)
+tilde_package()
 find_package(tilde REQUIRED)
 
 if(BUILD_TESTING)

--- a/src/tilde_sample/CMakeLists.txt
+++ b/src/tilde_sample/CMakeLists.txt
@@ -33,7 +33,8 @@ add_library(tilde_sample SHARED
   src/sample_publisher.cpp
   src/relay_timer.cpp
   src/relay_timer_with_buffer.cpp
-  src/goal.cpp)
+  src/goal.cpp
+  src/sample_stee_publisher.cpp)
 ament_target_dependencies(tilde_sample
     "rclcpp"
     "rclcpp_components"
@@ -56,7 +57,9 @@ rclcpp_components_register_node(tilde_sample
 rclcpp_components_register_node(tilde_sample
   PLUGIN "tilde_sample::Goal"
   EXECUTABLE goal)
-
+rclcpp_components_register_node(tilde_sample
+  PLUGIN "tilde_sample::SampleSteePublisherNode"
+  EXECUTABLE sample_stee_publisher)
 
 install(TARGETS
   tilde_sample)

--- a/src/tilde_sample/package.xml
+++ b/src/tilde_sample/package.xml
@@ -14,6 +14,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tilde</depend>
+  <depend>tilde_cmake</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>caret_lint_common</test_depend>

--- a/src/tilde_sample/package.xml
+++ b/src/tilde_sample/package.xml
@@ -15,7 +15,6 @@
   <depend>std_msgs</depend>
   <depend>tilde</depend>
 
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>caret_lint_common</test_depend>
 

--- a/src/tilde_sample/src/sample_stee_publisher.cpp
+++ b/src/tilde_sample/src/sample_stee_publisher.cpp
@@ -1,0 +1,90 @@
+// Copyright 2022 Research Institute of Systems Planning, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
+
+#include "std_msgs/msg/string.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+
+#include "tilde/stee_node.hpp"
+#include "tilde/stee_publisher.hpp"
+
+using namespace std::chrono_literals;
+
+const int64_t TIMER_MS_DEFAULT = 1000;
+
+namespace tilde_sample
+{
+
+class SampleSteePublisherNode : public tilde::SteeNode
+{
+public:
+  explicit SampleSteePublisherNode(const rclcpp::NodeOptions & options)
+  : SteeNode("sample_stee_publisher_node", options)
+  {
+    const std::string TIMER_MS = "timer_ms";
+
+    declare_parameter<int64_t>(TIMER_MS, TIMER_MS_DEFAULT);
+    auto timer_ms = get_parameter(TIMER_MS).get_value<int64_t>();
+    std::cout << "timer_ms: " << timer_ms << std::endl;
+
+    // Create a function for when messages are to be sent.
+    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    auto publish_message =
+      [this]() -> void
+      {
+        auto time_now = this->now();
+
+        msg_pc_ = std::make_unique<sensor_msgs::msg::PointCloud2>();
+        msg_pc_->header.stamp = time_now;
+        msg_pc_->header.frame_id = std::to_string(count_);
+        pub_pc_->publish(std::move(msg_pc_));
+
+        RCLCPP_INFO(
+          this->get_logger(), "Publishing PointCloud2: %ld stamp: %lu",
+          count_,
+          time_now.nanoseconds());
+
+        count_++;
+      };
+
+    // Create a publisher with a custom Quality of Service profile.
+    rclcpp::QoS qos(rclcpp::KeepLast(7));
+    pub_pc_ = this->create_stee_publisher<sensor_msgs::msg::PointCloud2>("topic_with_stamp", qos);
+
+    // Use a timer to schedule periodic message publishing.
+    auto dur = std::chrono::duration<int64_t, std::milli>(timer_ms);
+    timer_ = this->create_wall_timer(dur, publish_message);
+  }
+
+private:
+  size_t count_ = 0;
+  // message with standard header
+  std::unique_ptr<sensor_msgs::msg::PointCloud2> msg_pc_;
+  tilde::SteePublisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_pc_;
+
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+}  // namespace tilde_sample
+
+RCLCPP_COMPONENTS_REGISTER_NODE(tilde_sample::SampleSteePublisherNode)
+

--- a/src/tilde_sample/src/sample_stee_publisher.cpp
+++ b/src/tilde_sample/src/sample_stee_publisher.cpp
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
+#include "tilde/stee_node.hpp"
+#include "tilde/stee_publisher.hpp"
+
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "std_msgs/msg/string.hpp"
+
 #include <chrono>
 #include <cstdio>
 #include <memory>
 #include <string>
 #include <utility>
-
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp_components/register_node_macro.hpp"
-
-#include "std_msgs/msg/string.hpp"
-#include "sensor_msgs/msg/point_cloud2.hpp"
-
-#include "tilde/stee_node.hpp"
-#include "tilde/stee_publisher.hpp"
 
 using namespace std::chrono_literals;
 
@@ -48,23 +47,20 @@ public:
 
     // Create a function for when messages are to be sent.
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-    auto publish_message =
-      [this]() -> void
-      {
-        auto time_now = this->now();
+    auto publish_message = [this]() -> void {
+      auto time_now = this->now();
 
-        msg_pc_ = std::make_unique<sensor_msgs::msg::PointCloud2>();
-        msg_pc_->header.stamp = time_now;
-        msg_pc_->header.frame_id = std::to_string(count_);
-        pub_pc_->publish(std::move(msg_pc_));
+      msg_pc_ = std::make_unique<sensor_msgs::msg::PointCloud2>();
+      msg_pc_->header.stamp = time_now;
+      msg_pc_->header.frame_id = std::to_string(count_);
+      pub_pc_->publish(std::move(msg_pc_));
 
-        RCLCPP_INFO(
-          this->get_logger(), "Publishing PointCloud2: %ld stamp: %lu",
-          count_,
-          time_now.nanoseconds());
+      RCLCPP_INFO(
+        this->get_logger(), "Publishing PointCloud2: %ld stamp: %lu", count_,
+        time_now.nanoseconds());
 
-        count_++;
-      };
+      count_++;
+    };
 
     // Create a publisher with a custom Quality of Service profile.
     rclcpp::QoS qos(rclcpp::KeepLast(7));
@@ -87,4 +83,3 @@ private:
 }  // namespace tilde_sample
 
 RCLCPP_COMPONENTS_REGISTER_NODE(tilde_sample::SampleSteePublisherNode)
-

--- a/src/tilde_vis_test/package.xml
+++ b/src/tilde_vis_test/package.xml
@@ -15,7 +15,6 @@
   <depend>std_msgs</depend>
   <depend>tilde</depend>
 
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>caret_lint_common</test_depend>
 


### PR DESCRIPTION
We need to update the template API to follow the changes from humble.

Build error message:

```
$ colcon biuld   # on humble
src/tilde/include/tilde/stee_node.hpp:146:35: error: cannot convert ‘shared_ptr<Subscription<[...],[...],tilde_msg
::msg::SteeImu_<std::allocator<void> >,[...],[...]>>’ to ‘shared_ptr<Subscription<[...],[...],rclcpp::message_memory_strategy::MessageMemoryStrategy<tilde_msg::msg::SteeImu
_<std::allocator<void> >, std::allocator<void> >,[...],[...]>>’                                                                                                             
  146 |       stee_sub->set_converted_sub(converted_sub);                                                                                                                   
      |                                   ^~~~~~~~~~~~~                                                                                                                     
      |                                   |                                                                                                                                 
      |                                   shared_ptr<Subscription<[...],[...],tilde_msg::msg::SteeImu_<std::allocator<void> >,[...],[...]>> 
(snip)
```
