### PR TITLE
feat: read parameters dynamically

### DIFF
--- a/src/tilde/include/tilde/stee_node.hpp
+++ b/src/tilde/include/tilde/stee_node.hpp
@@ -88,10 +88,7 @@ public:
     std::shared_ptr<ConvertedSubscriptionT> converted_sub{nullptr};
     auto stee_sub = std::make_shared<SteeSubscriptionT>();
 
-    // TODO(y-okumura-isp): make instance variable
-    bool enable_stee = true;
-
-    if (enable_stee) {
+    if (enable_stee_) {
       using rclcpp::node_interfaces::get_node_topics_interface;
       auto node_topics_interface = get_node_topics_interface(this);
       auto resolved_topic_name = node_topics_interface->resolve_topic_name(topic_name);
@@ -221,6 +218,15 @@ private:
    * We can set it only by startup option for now.
    */
   std::set<std::string> stop_topics_;
+
+  /// Enable STEE or not
+  /**
+   * We can set this parameter by "enable_stee" only at initialization.
+   * This is because if we change "enable/disable" dynamically,
+   * we need to dynamically change the message type (original type or STEE type).
+   * We cannot do this without re-create the publisher/subscription pair.
+   */
+  bool enable_stee_;
 
   template <class MessageT, class ConvertedMessageT = ConvertedMessageType<MessageT>>
   void set_source_table(const std::string & topic, const ConvertedMessageT * msg)

--- a/src/tilde/include/tilde/stee_node.hpp
+++ b/src/tilde/include/tilde/stee_node.hpp
@@ -226,7 +226,7 @@ private:
    * we need to dynamically change the message type (original type or STEE type).
    * We cannot do this without re-create the publisher/subscription pair.
    */
-  bool enable_stee_;
+  bool enable_stee_{};
 
   template <class MessageT, class ConvertedMessageT = ConvertedMessageType<MessageT>>
   void set_source_table(const std::string & topic, const ConvertedMessageT * msg)

--- a/src/tilde/include/tilde/tilde_node.hpp
+++ b/src/tilde/include/tilde/tilde_node.hpp
@@ -15,6 +15,7 @@
 #ifndef TILDE__TILDE_NODE_HPP_
 #define TILDE__TILDE_NODE_HPP_
 
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/message_info.hpp"
 #include "rclcpp/node.hpp"
@@ -110,7 +111,7 @@ public:
 
     auto main_topic_callback = [this, resolved_topic_name, callback,
                                 callback_addr](CallbackArgT msg) -> void {
-      if (this->enable_tilde) {
+      if (this->enable_tilde_) {
         auto subscription_time = this->now();
         auto subscription_time_steady = this->steady_clock_->now();
 
@@ -147,7 +148,7 @@ public:
 
     auto tilde_pub = std::make_shared<TildePublisherT>(
       info_pub, pub, get_fully_qualified_name(), this->get_clock(), steady_clock_,
-      this->enable_tilde);
+      this->enable_tilde_);
     tilde_pubs_[info_topic] = tilde_pub;
 
     tracepoint(
@@ -246,8 +247,11 @@ private:
   std::shared_ptr<rclcpp::Clock> steady_clock_;
 
   /// whether to enable tilde
-  // TODO(y-okumura-isp) enable dynamic configuration
-  bool enable_tilde;
+  bool enable_tilde_;
+
+  OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
+
+  void init();
 };
 
 }  // namespace tilde

--- a/src/tilde/include/tilde/tilde_node.hpp
+++ b/src/tilde/include/tilde/tilde_node.hpp
@@ -79,7 +79,7 @@ public:
     const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   RCLCPP_PUBLIC
-  virtual ~TildeNode();
+  virtual ~TildeNode() = default;
 
   /// create custom subscription
   template <

--- a/src/tilde/include/tilde/tilde_publisher.hpp
+++ b/src/tilde/include/tilde/tilde_publisher.hpp
@@ -304,7 +304,7 @@ public:
     std::shared_ptr<MessageTrackingTagPublisher> info_pub, std::shared_ptr<PublisherT> pub,
     const std::string & node_fqn, std::shared_ptr<rclcpp::Clock> clock,
     std::shared_ptr<rclcpp::Clock> steady_clock, bool enable)
-  : TildePublisherBase(clock, steady_clock, node_fqn, enable), info_pub_(info_pub), pub_(pub)
+  : TildePublisherBase(clock, steady_clock, node_fqn, enable), info_pub_(std::move(info_pub), pub_(pub)
   {
   }
 

--- a/src/tilde/include/tilde/tilde_publisher.hpp
+++ b/src/tilde/include/tilde/tilde_publisher.hpp
@@ -179,8 +179,8 @@ public:
    * \param[in] enable enable TILDE or not
    */
   explicit TildePublisherBase(
-    std::shared_ptr<rclcpp::Clock> clock, std::shared_ptr<rclcpp::Clock> steady_clock,
-    const std::string & node_fqn, bool enable = true);
+    const std::shared_ptr<rclcpp::Clock> & clock,
+    const std::shared_ptr<rclcpp::Clock> & steady_clock, std::string node_fqn, bool enable = true);
 
   /// Set implicit input info
   /**
@@ -302,9 +302,9 @@ public:
   /// Default constructor
   TildePublisher(
     std::shared_ptr<MessageTrackingTagPublisher> info_pub, std::shared_ptr<PublisherT> pub,
-    const std::string & node_fqn, std::shared_ptr<rclcpp::Clock> clock,
-    std::shared_ptr<rclcpp::Clock> steady_clock, bool enable)
-  : TildePublisherBase(clock, steady_clock, node_fqn, enable), info_pub_(std::move(info_pub), pub_(pub)
+    const std::string & node_fqn, const std::shared_ptr<rclcpp::Clock> & clock,
+    const std::shared_ptr<rclcpp::Clock> & steady_clock, bool enable)
+  : TildePublisherBase(clock, steady_clock, node_fqn, enable), info_pub_(info_pub), pub_(pub)
   {
   }
 
@@ -359,8 +359,7 @@ public:
 
   // TODO(y-okumura-isp) get_allocator
 
-  size_t get_subscription_count() const {
-    return pub_->get_subscription_count(); }
+  size_t get_subscription_count() const { return pub_->get_subscription_count(); }
 
   size_t get_intra_process_subscription_count() const
   {
@@ -368,8 +367,7 @@ public:
   }
 
   RCLCPP_PUBLIC
-  const char * get_topic_name() const {
-    return pub_->get_topic_name(); }
+  const char * get_topic_name() const { return pub_->get_topic_name(); }
 
 private:
   std::shared_ptr<MessageTrackingTagPublisher> info_pub_;

--- a/src/tilde/include/tilde/tilde_publisher.hpp
+++ b/src/tilde/include/tilde/tilde_publisher.hpp
@@ -176,10 +176,11 @@ public:
    * \param[in] clock for RCL_ROS_TIME
    * \param[in] clock for RCL_STEADY_TIME
    * \param[in] node_fqn a node name
+   * \param[in] enable enable TILDE or not
    */
   explicit TildePublisherBase(
     std::shared_ptr<rclcpp::Clock> clock, std::shared_ptr<rclcpp::Clock> steady_clock,
-    const std::string & node_fqn);
+    const std::string & node_fqn, bool enable = true);
 
   /// Set implicit input info
   /**
@@ -249,6 +250,12 @@ public:
   bool get_input_info(
     const std::string & topic, const rclcpp::Time & header_stamp, InputInfo & info);
 
+  /// Enable or disable TILDE
+  /**
+   * \param[in] enable boolean
+   */
+  void set_enable(bool enable);
+
   void print_input_infos();
 
 protected:
@@ -259,6 +266,8 @@ protected:
   int64_t seq_;
 
   std::map<std::string, std::string> sub_topics_;
+
+  bool enable_;
 
 private:
   // parent node subscription topic vs InputInfo
@@ -295,10 +304,7 @@ public:
     std::shared_ptr<MessageTrackingTagPublisher> info_pub, std::shared_ptr<PublisherT> pub,
     const std::string & node_fqn, std::shared_ptr<rclcpp::Clock> clock,
     std::shared_ptr<rclcpp::Clock> steady_clock, bool enable)
-  : TildePublisherBase(clock, steady_clock, node_fqn),
-    info_pub_(info_pub),
-    pub_(pub),
-    enable_(enable)
+  : TildePublisherBase(clock, steady_clock, node_fqn, enable), info_pub_(info_pub), pub_(pub)
   {
   }
 
@@ -367,7 +373,6 @@ private:
   std::shared_ptr<MessageTrackingTagPublisher> info_pub_;
   std::shared_ptr<PublisherT> pub_;
   const std::string node_fqn_;
-  bool enable_;
 
   /// Publish MessageTrackingTag
   /**

--- a/src/tilde/include/tilde/tilde_publisher.hpp
+++ b/src/tilde/include/tilde/tilde_publisher.hpp
@@ -179,8 +179,8 @@ public:
    * \param[in] enable enable TILDE or not
    */
   explicit TildePublisherBase(
-    const std::shared_ptr<rclcpp::Clock> & clock,
-    const std::shared_ptr<rclcpp::Clock> & steady_clock, std::string node_fqn, bool enable = true);
+    std::shared_ptr<rclcpp::Clock> clock, std::shared_ptr<rclcpp::Clock> steady_clock,
+    std::string node_fqn, bool enable = true);
 
   /// Set implicit input info
   /**

--- a/src/tilde/include/tilde/tilde_publisher.hpp
+++ b/src/tilde/include/tilde/tilde_publisher.hpp
@@ -359,7 +359,8 @@ public:
 
   // TODO(y-okumura-isp) get_allocator
 
-  size_t get_subscription_count() const { return pub_->get_subscription_count(); }
+  size_t get_subscription_count() const {
+    return pub_->get_subscription_count(); }
 
   size_t get_intra_process_subscription_count() const
   {
@@ -367,7 +368,8 @@ public:
   }
 
   RCLCPP_PUBLIC
-  const char * get_topic_name() const { return pub_->get_topic_name(); }
+  const char * get_topic_name() const {
+    return pub_->get_topic_name(); }
 
 private:
   std::shared_ptr<MessageTrackingTagPublisher> info_pub_;

--- a/src/tilde/src/stee_node.cpp
+++ b/src/tilde/src/stee_node.cpp
@@ -40,6 +40,9 @@ void SteeNode::init()
   // TODO(y-okumura-isp): set appropriate max stamps
   source_table_.reset(new SteeSourcesTable(100));
 
+  declare_parameter<bool>("enable_stee", true);
+  get_parameter("enable_stee", enable_stee_);
+
   auto stop_topics_vec = declare_parameter<std::vector<std::string>>(
     "stee_stop_topics",
     std::vector<std::string>{

--- a/src/tilde/src/tilde_node.cpp
+++ b/src/tilde/src/tilde_node.cpp
@@ -21,10 +21,7 @@ using tilde::TildeNode;
 TildeNode::TildeNode(const std::string & node_name, const rclcpp::NodeOptions & options)
 : Node(node_name, options)
 {
-  steady_clock_.reset(new rclcpp::Clock(RCL_STEADY_TIME));
-  this->declare_parameter<bool>("enable_tilde", true);
-
-  this->get_parameter("enable_tilde", enable_tilde);
+  init();
 }
 
 TildeNode::TildeNode(
@@ -32,10 +29,33 @@ TildeNode::TildeNode(
   const rclcpp::NodeOptions & options)
 : Node(node_name, namespace_, options)
 {
+  init();
+}
+
+void TildeNode::init()
+{
   steady_clock_.reset(new rclcpp::Clock(RCL_STEADY_TIME));
   this->declare_parameter<bool>("enable_tilde", true);
 
-  this->get_parameter("enable_tilde", enable_tilde);
+  this->get_parameter("enable_tilde", enable_tilde_);
+
+  param_callback_handle_ =
+    this->add_on_set_parameters_callback([this](std::vector<rclcpp::Parameter> parameters) {
+      auto result = rcl_interfaces::msg::SetParametersResult();
+
+      result.successful = true;
+      for (auto parameter : parameters) {
+        if (parameter.get_name() == "enable_tilde") {
+          enable_tilde_ = parameter.as_bool();
+          for (auto & [topic, pub] : tilde_pubs_) {
+            (void)topic;
+            pub->set_enable(enable_tilde_);
+          }
+        }
+      }
+
+      return result;
+    });
 }
 
 TildeNode::~TildeNode() {}

--- a/src/tilde/src/tilde_node.cpp
+++ b/src/tilde/src/tilde_node.cpp
@@ -40,11 +40,11 @@ void TildeNode::init()
   this->get_parameter("enable_tilde", enable_tilde_);
 
   param_callback_handle_ =
-    this->add_on_set_parameters_callback([this](std::vector<rclcpp::Parameter> parameters) {
+    this->add_on_set_parameters_callback([this](const std::vector<rclcpp::Parameter> & parameters) {
       auto result = rcl_interfaces::msg::SetParametersResult();
 
       result.successful = true;
-      for (auto parameter : parameters) {
+      for (const auto & parameter : parameters) {
         if (parameter.get_name() == "enable_tilde") {
           enable_tilde_ = parameter.as_bool();
           for (auto & [topic, pub] : tilde_pubs_) {
@@ -57,5 +57,3 @@ void TildeNode::init()
       return result;
     });
 }
-
-TildeNode::~TildeNode() {}

--- a/src/tilde/src/tilde_publisher.cpp
+++ b/src/tilde/src/tilde_publisher.cpp
@@ -36,11 +36,12 @@ rclcpp::Time tilde::get_timestamp(rclcpp::Time t, ...)
 
 TildePublisherBase::TildePublisherBase(
   std::shared_ptr<rclcpp::Clock> clock, std::shared_ptr<rclcpp::Clock> steady_clock,
-  const std::string & node_fqn)
+  const std::string & node_fqn, bool enable)
 : clock_(clock),
   steady_clock_(steady_clock),
   node_fqn_(node_fqn),
   seq_(0),
+  enable_(enable),
   is_explicit_(false),
   MAX_SUB_CALLBACK_INFOS_SEC_(2)
 {
@@ -159,6 +160,8 @@ bool TildePublisherBase::get_input_info(
   info = *(it->second);
   return true;
 }
+
+void TildePublisherBase::set_enable(bool enable) { enable_ = enable; }
 
 void TildePublisherBase::print_input_infos()
 {

--- a/src/tilde/src/tilde_publisher.cpp
+++ b/src/tilde/src/tilde_publisher.cpp
@@ -35,11 +35,11 @@ rclcpp::Time tilde::get_timestamp(rclcpp::Time t, ...)
 }
 
 TildePublisherBase::TildePublisherBase(
-  std::shared_ptr<rclcpp::Clock> clock, std::shared_ptr<rclcpp::Clock> steady_clock,
-  const std::string & node_fqn, bool enable)
+  const std::shared_ptr<rclcpp::Clock> & clock, const std::shared_ptr<rclcpp::Clock> & steady_clock,
+  std::string node_fqn, bool enable)
 : clock_(clock),
   steady_clock_(steady_clock),
-  node_fqn_(node_fqn),
+  node_fqn_(std::move(node_fqn)),
   seq_(0),
   enable_(enable),
   is_explicit_(false),

--- a/src/tilde/src/tilde_publisher.cpp
+++ b/src/tilde/src/tilde_publisher.cpp
@@ -35,10 +35,10 @@ rclcpp::Time tilde::get_timestamp(rclcpp::Time t, ...)
 }
 
 TildePublisherBase::TildePublisherBase(
-  const std::shared_ptr<rclcpp::Clock> & clock, const std::shared_ptr<rclcpp::Clock> & steady_clock,
+  std::shared_ptr<rclcpp::Clock> clock, std::shared_ptr<rclcpp::Clock> steady_clock,
   std::string node_fqn, bool enable)
-: clock_(clock),
-  steady_clock_(steady_clock),
+: clock_(std::move(clock)),
+  steady_clock_(std::move(steady_clock)),
   node_fqn_(std::move(node_fqn)),
   seq_(0),
   enable_(enable),

--- a/src/tilde/test/test_tilde_node.cpp
+++ b/src/tilde/test/test_tilde_node.cpp
@@ -426,12 +426,12 @@ public:
     this->declare_parameter<std::string>("child_param", "original");
     this->get_parameter("child_param", child_param_);
 
-    param_callback_handle_ =
-      this->add_on_set_parameters_callback([this](std::vector<rclcpp::Parameter> parameters) {
+    param_callback_handle_ = this->add_on_set_parameters_callback(
+      [this](const std::vector<rclcpp::Parameter> & parameters) {
         auto result = rcl_interfaces::msg::SetParametersResult();
 
         result.successful = true;
-        for (auto parameter : parameters) {
+        for (const auto & parameter : parameters) {
           if (parameter.get_name() == "child_param") {
             child_param_ = parameter.as_string();
           }
@@ -457,7 +457,7 @@ TEST_F(TestTildeNode, child_param_callback)
   node->get_parameter("enable_tilde", enable_tilde);
   EXPECT_TRUE(enable_tilde);
 
-  std::string child_param = "";
+  std::string child_param;
   node->get_parameter("child_param", child_param);
   EXPECT_EQ(child_param, "original");
 


### PR DESCRIPTION
We summarized the parameter list to decide whether to support dynamic configuration or not.
The "S/D" column means static or dynamic configuration. We can specify static configuration only in initialization, namely by CUI options or the parameter file.

Here is the list.

## tilde Package

### TildeNode

| name         | S/D | comment                                            |
| ------------ | --- | -------------------------------------------------- |
| enable_tilde | D   | Selecting ON/OFF looks good for measurement usage. |

### SteeNode

| name             | S/D | comment                                                                                |
| ---------------- | --- | -------------------------------------------------------------------------------------- |
| enable_stee      | S   | We need to re-create the publisher/subscription pair to support dynamic configuration. |
| stee_stop_topics | S   | It's determined by topic structure.                                                    |

## TildeDeadlineDetectorNode

Almost all parameters are either determined by by the topic structure, or debug usage.
So we'll support the dynamic configuration only if it's needed.

| name                     | S/D |
| ------------------------ | --- |
| `ignore_topics`          | S   |
| `sensor_topics`          | S   |
| `target_topics`          | S   |
| `deadline_ms`            | S   |
| `skips_main_out`         | S   |
| `skips_main_in`          | S   |
| `expire_ms`              | S   |
| `cleanup_ms`             | S   |
| `print_report`           | S   |
| `print_pending_messages` | S   |
| `clock_work_around`      | S   |
| `show_performance`       | S   |
